### PR TITLE
Improved answer filtering

### DIFF
--- a/front-end/src/components/Game.vue
+++ b/front-end/src/components/Game.vue
@@ -111,12 +111,12 @@
                                     <!-- OTHER PLAYER ANSWER COUNT -->
                                     <div>
                                         The other player has submitted
-                                        <b v-if="no_of_opponent_answers" style="color:#67C23A;">
-                                            {{ no_of_opponent_answers }}
-                                        </b>
-                                        <b v-else style="color:#F56C6C;">
-                                            {{ no_of_opponent_answers }}
-                                        </b>
+                                        <b v-if="no_of_opponent_answers" style="color:#67C23A;">{{
+                                            no_of_opponent_answers
+                                        }}</b>
+                                        <b v-else style="color:#F56C6C;">{{
+                                            no_of_opponent_answers
+                                        }}</b>
                                         answers
                                     </div>
                                     <hr />
@@ -332,18 +332,22 @@ export default {
             const words = _.words(_.toLower(this.input))
 
             words.forEach(word => {
-                const x = { answer: word }
-                const cond1 = !_.filter(this.answers, x).length
-                const cond2 = word.length
-                const cond3 = word !== _.toLower(this.game.words[this.current_word_index].word)
-                const cond4 = !_.words(
-                    _.toLower(this.game.words[this.current_word_index].definition)
-                ).includes(_.toLower(word))
+                const cond1 = !this.answers.includes(word)
+                const cond2 = !!word.length
+                const cond3 =
+                    word.indexOf(_.toLower(this.game.words[this.current_word_index].word)) === -1 &&
+                    _.toLower(this.game.words[this.current_word_index].word).indexOf(word) === -1
+                const cond4 =
+                    word.indexOf(_.toLower(this.game.words[this.current_word_index].definition)) ===
+                        -1 &&
+                    _.toLower(this.game.words[this.current_word_index].definition).indexOf(word) ===
+                        -1
                 if (cond1 && cond2 && cond3 && cond4) {
                     this.answers.push(x)
                     data.answers.push(x)
                 }
             })
+
             if (data.answers.length) {
                 e.preventDefault()
                 this.socket.emit('submitAnswer', data)

--- a/front-end/src/components/SinglePlayerGame.vue
+++ b/front-end/src/components/SinglePlayerGame.vue
@@ -225,13 +225,16 @@ export default {
             const words = _.words(_.toLower(this.input))
 
             words.forEach(word => {
-                const x = { answer: word }
-                const cond1 = !_.filter(this.answers, x).length
-                const cond2 = word.length
-                const cond3 = word !== _.toLower(this.game.words[this.current_word_index].word)
-                const cond4 = !_.words(
-                    _.toLower(this.game.words[this.current_word_index].definition)
-                ).includes(_.toLower(word))
+                const cond1 = !this.answers.includes(word)
+                const cond2 = !!word.length
+                const cond3 =
+                    word.indexOf(_.toLower(this.game.words[this.current_word_index].word)) === -1 &&
+                    _.toLower(this.game.words[this.current_word_index].word).indexOf(word) === -1
+                const cond4 =
+                    word.indexOf(_.toLower(this.game.words[this.current_word_index].definition)) ===
+                        -1 &&
+                    _.toLower(this.game.words[this.current_word_index].definition).indexOf(word) ===
+                        -1
                 if (cond1 && cond2 && cond3 && cond4) {
                     this.answers.push(x)
                     data.answers.push(x)


### PR DESCRIPTION
Now any substrings of the word or the description are not counted. Also if the word is a substring of the answer

Examples of this are:
- word: 'feeling', answer: 'feel'
- word: 'feel', answer: 'feeling'
- desc: 'a nice feeling', answer: 'feeling'